### PR TITLE
fix: replaced unsupported git in pre-commit url with https

### DIFF
--- a/circleci-orb-{{cookiecutter.orb_name}}/.pre-commit-config.yaml
+++ b/circleci-orb-{{cookiecutter.orb_name}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 fail_fast: true
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-json


### PR DESCRIPTION
## Description
The git protocol isn't supported anymore by GitHub, fixed the problem by changing to https